### PR TITLE
helm(neo): scale-ready defaults for postgres + api

### DIFF
--- a/charts/netapp-neo/templates/postgres-statefulset.yaml
+++ b/charts/netapp-neo/templates/postgres-statefulset.yaml
@@ -18,10 +18,26 @@ spec:
       labels:
         {{- include "netapp-neo.selectorLabels" (dict "context" . "component" "postgres") | nindent 8 }}
     spec:
+      {{- with .Values.postgresql.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.postgresql.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: postgres
           image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
           imagePullPolicy: {{ .Values.postgresql.image.pullPolicy }}
+          {{- with .Values.postgresql.extraArgs }}
+          args:
+            - postgres
+            {{- range . }}
+            - "-c"
+            - {{ . | quote }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: postgres
               containerPort: 5432

--- a/charts/netapp-neo/values.yaml
+++ b/charts/netapp-neo/values.yaml
@@ -198,5 +198,17 @@ postgresql:
     size: 8Gi
     annotations: {}
   resources: {}
+  # Pin postgres to a specific node when its PVC is on local-path / hostpath
+  # storage. Leave empty to let the scheduler decide.
+  nodeSelector: {}
+  tolerations: []
+  # Postgres command-line tuning passed via -c. Defaults set the safety net
+  # against share-creation-blocking-on-readers (see EVIDENCE F10):
+  #   idle_in_transaction_session_timeout=60s caps how long a transaction can
+  #   sit idle while still holding locks; auto-aborts and releases its locks
+  #   after the timeout. Without it a stuck client can block partition creates
+  #   for any new share indefinitely.
+  extraArgs:
+    - "idle_in_transaction_session_timeout=60s"
   # When postgresql.enabled is false, set this to your external DB URL
   externalDatabaseUrl: ""

--- a/charts/netapp-neo/values.yaml
+++ b/charts/netapp-neo/values.yaml
@@ -27,7 +27,17 @@ api:
     className:
     annotations: {}
     tls: []
-  resources: {}
+  # Defaults sized for medium deployments (≤ 100 M files / ≤ 100 shares).
+  # For multi-billion-file deployments, override limits.memory to 8Gi+ and
+  # see the PERFORMANCE_TUNING_GUIDE — cross-share endpoints can build large
+  # responses in memory.
+  resources:
+    requests:
+      cpu: "500m"
+      memory: "1Gi"
+    limits:
+      cpu: "2"
+      memory: "4Gi"
   env:
     # JWT
     JWT_SECRET_KEY: ""


### PR DESCRIPTION
## Summary

Two commits making the Neo 4.x Helm chart usable at scale without a fork.

## Changes

### 1. \`07e1068\` — api resource defaults

The chart shipped \`resources: {}\` for the api component. During 1 B-row scale testing the API pod was OOMKilled twice under modest read load because Kubernetes fell back to whatever implicit memory limit the cluster applied (often 4 GiB).

Sets conservative defaults (1 GiB request / 4 GiB limit) sized for medium deployments (≤ 100 M files). Multi-billion-file deployments override via values overlay.

### 2. \`1e40a40\` — postgres scale enablers

Three additions to the postgres StatefulSet, all backward-compatible:

- **\`nodeSelector\` + \`tolerations\`** — required when postgres uses local-path or any host-pinned storage class and must land on a specific node (which is every production deployment using local NVMe).
- **\`extraArgs\`** — list of raw \`-c key=value\` flags passed on the postgres command line. Lets operators apply tuning (shared_buffers, work_mem, max_connections, etc.) without templating a custom \`postgresql.conf\` or forking the chart.
- **Default \`extraArgs\`** sets \`idle_in_transaction_session_timeout=60s\`. Without this, an API session left idle inside a transaction (one that previously read \`file_metadata\`) holds \`AccessShareLock\` indefinitely, blocking the \`AccessExclusiveLock\` that \`POST /api/v1/shares\` needs to CREATE the new per-share partition. At high-tenancy fan-out this turns share creation into an unbounded hang.

Observed in 4.1.0 scale testing: a 2 B-row injection stalled for 1 hour on its very first partition because an API background task was idle-in-transaction with a \`SELECT vd.* FROM virtual_datasets\` query open. The timeout would have auto-released the lock after 60 s.

## Companion

Application-side fix lives in NetApp/netapp-copilot-connector-gen-2#38 (\`feature/scale-perf-fixes\`): a \`SET LOCAL lock_timeout = '30s'\` around the partition \`CREATE\` so the API fails fast instead of hanging its request thread for minutes, with the existing SAVEPOINT + error handling already in place.

## Test plan

- [x] \`helm template\` renders clean with defaults
- [x] \`helm upgrade\` from prior chart version is non-disruptive (validated on 2 B-row scale-test cluster)
- [x] \`pg_settings\` confirms \`idle_in_transaction_session_timeout\` active post-deploy
- [x] New \`nodeSelector\` / \`tolerations\` fields default to empty → no scheduling change for existing deployments