### PR TITLE
docs: Neo v4.1.4 — Virtual Datasets, IP redaction, version updates

### DIFF
--- a/docs/projects/mlai/neo/core/d-configuration.md
+++ b/docs/projects/mlai/neo/core/d-configuration.md
@@ -114,7 +114,7 @@ You have successfully switched the connector to PRODUCTION mode. You can now beg
 | `JWT_SECRET_KEY` | *(auto-generated)* | Secret key for signing JWT tokens |
 | `ACCESS_TOKEN_EXPIRE_MINUTES` | `1440` | JWT token expiry time in minutes |
 | **Encryption** | | |
-| `ENCRYPTION_KEY` | *(auto-generated)* | Fernet key for encrypting stored credentials |
+| `ENCRYPTION_KEY` | *(auto-generated)* | Key for encrypting stored credentials |
 | **License** | | |
 | `NETAPP_CONNECTOR_LICENSE` | *(none)* | Pre-configure license key via environment |
 | `CONNECTOR_ID` | *(auto-generated)* | Unique identifier for this connector instance |

--- a/docs/projects/mlai/neo/core/m-api.md
+++ b/docs/projects/mlai/neo/core/m-api.md
@@ -182,7 +182,7 @@ Response:
 {
   "status": "healthy",
   "service": "api",
-  "version": "4.0.2",
+  "version": "4.1.4",
   "timestamp": "2026-03-10T12:00:00+00:00"
 }
 ```
@@ -197,7 +197,7 @@ Response:
 {
   "status": "healthy",
   "service": "api",
-  "version": "4.0.2",
+  "version": "4.1.4",
   "components": {
     "database": "ok",
     "oauth": "configured"
@@ -380,6 +380,29 @@ Background task management.
 | DELETE | `/api/v1/tasks/{task_id}` | Cancel a running task |
 | GET | `/api/v1/tasks/statistics/summary` | Task statistics summary |
 | GET | `/api/v1/tasks/statistics/acl-cache` | ACL cache statistics |
+
+### Virtual Datasets
+
+Curated, shareable file collections with independent access controls. See the [Virtual Datasets Guide](./m-datasets.md) for full details.
+
+| Method | Endpoint | Description |
+| ------ | -------- | ----------- |
+| POST | `/api/v1/datasets` | Create a dataset |
+| GET | `/api/v1/datasets` | List accessible datasets |
+| GET | `/api/v1/datasets/expiring` | List expiring datasets (admin) |
+| GET | `/api/v1/datasets/{id}` | Get dataset details |
+| PATCH | `/api/v1/datasets/{id}` | Update dataset metadata |
+| DELETE | `/api/v1/datasets/{id}` | Delete dataset |
+| POST | `/api/v1/datasets/{id}/items` | Add files to dataset |
+| GET | `/api/v1/datasets/{id}/items` | List files in dataset |
+| DELETE | `/api/v1/datasets/{id}/items` | Remove files from dataset |
+| POST | `/api/v1/datasets/{id}/search` | Full-text search within dataset |
+| POST | `/api/v1/datasets/{id}/ner-search` | Named entity search within dataset |
+| POST | `/api/v1/datasets/{id}/subset` | Create a subset dataset |
+| POST | `/api/v1/datasets/{id}/shares` | Share dataset |
+| GET | `/api/v1/datasets/{id}/shares` | List shares |
+| PATCH | `/api/v1/datasets/{id}/shares/{share_id}` | Update share |
+| DELETE | `/api/v1/datasets/{id}/shares/{share_id}` | Revoke share |
 
 ### Health
 

--- a/docs/projects/mlai/neo/core/m-console.md
+++ b/docs/projects/mlai/neo/core/m-console.md
@@ -19,7 +19,7 @@ curl --location 'http://<server-ip>:8000/api/v1/setup/initial-credentials'
 
 The console provides a full-text search interface for querying indexed content across all configured shares. Search features include:
 
-- **Full-text search**: Search across all extracted document content using natural language queries. Results are ranked by relevance using PostgreSQL GIN-indexed search vectors.
+- **Full-text search**: Search across all extracted document content using natural language queries. Results are ranked by relevance.
 - **Filters**: Narrow results by share, file type, date range, or NER entity tags.
 - **File preview**: View extracted content and metadata for any search result.
 - **Export**: Download search results for further analysis.

--- a/docs/projects/mlai/neo/core/m-datasets.md
+++ b/docs/projects/mlai/neo/core/m-datasets.md
@@ -1,0 +1,573 @@
+# Virtual Datasets
+
+Virtual Datasets are curated, shareable collections of indexed files that can span multiple shares and storage protocols. They allow users to group files from across SMB, NFS, and S3 sources into a single searchable collection, share it with colleagues or Entra ID groups, and control access independently of the underlying file-level permissions.
+
+> [!IMPORTANT]
+> Virtual Datasets require PostgreSQL. Deployments using MySQL will receive an HTTP 501 response for all dataset endpoints.
+
+All dataset operations require authentication. Obtain a bearer token before making API calls:
+
+```bash
+TOKEN=$(curl -s -X POST http://localhost:8000/api/v1/token \
+  -d "username=admin&password=yourpassword" | jq -r .access_token)
+```
+
+Every example on this page uses this `$TOKEN` variable.
+
+---
+
+## Key Capabilities
+
+| Capability | Description |
+|------------|-------------|
+| **Multi-protocol** | A single dataset can contain files from SMB, NFS, and S3 shares |
+| **Collaboration** | Share datasets with local users, Entra ID users, or Entra ID groups |
+| **Granular permissions** | READ, WRITE, ADMIN, and OWNER permission levels |
+| **Scoped search** | Full-text and named entity search within a dataset |
+| **ACL override** | Optionally bypass file-level ACLs so shared users can see all items |
+| **Auto-expiration** | Datasets expire after a configurable period (default 90 days) |
+| **Subset creation** | Create new datasets from filtered subsets of existing ones |
+| **Audit logging** | All operations are recorded for compliance and monitoring |
+| **Rate limiting** | Per-user rate limits protect system resources |
+
+---
+
+## Permission Model
+
+Access to a dataset is determined by a four-level permission hierarchy:
+
+| Level | Capabilities |
+|-------|-------------|
+| **READ** | View dataset metadata, list items, search within the dataset |
+| **WRITE** | Everything in READ, plus add and remove items |
+| **ADMIN** | Everything in WRITE, plus share with others and update dataset settings |
+| **OWNER** | Full control including deletion (assigned to the dataset creator) |
+
+When a user matches multiple shares (for example, via both a direct share and a group share), the highest permission applies.
+
+**Public datasets** grant READ access to all authenticated users without requiring an explicit share.
+
+---
+
+## Creating a Dataset
+
+```
+POST /api/v1/datasets
+```
+
+Creates a new dataset from a list of file IDs. File IDs are typically obtained from a [search](m-search) or [file listing](m-files) operation.
+
+### Request
+
+```bash
+curl -X POST http://localhost:8000/api/v1/datasets \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Q4 Financial Reports",
+    "description": "All Q4 reports across regional shares",
+    "file_ids": ["a1b2c3...", "d4e5f6...", "g7h8i9..."],
+    "is_public": false,
+    "acl_override_enabled": false,
+    "expires_at": "2026-09-01T00:00:00Z"
+  }'
+```
+
+### Parameters
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | string | *(required)* | Dataset name (1--255 characters) |
+| `description` | string | `null` | Optional description |
+| `file_ids` | array | *(required)* | One or more file IDs to include |
+| `source_query` | object | `null` | Optional metadata about the original search query |
+| `is_public` | boolean | `false` | Make visible to all authenticated users |
+| `acl_override_enabled` | boolean | `false` | Bypass file-level ACLs for shared users |
+| `expires_at` | datetime | 90 days from now | Expiration date (configurable via `DATASET_DEFAULT_EXPIRATION_DAYS`) |
+
+### Response (201 Created)
+
+```json
+{
+  "id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+  "name": "Q4 Financial Reports",
+  "description": "All Q4 reports across regional shares",
+  "owner_id": 1,
+  "owner_username": "admin",
+  "is_public": false,
+  "acl_override_enabled": false,
+  "item_count": 3,
+  "created_at": "2026-05-21T10:00:00Z",
+  "updated_at": "2026-05-21T10:00:00Z",
+  "expires_at": "2026-09-01T00:00:00Z",
+  "expires_in_hours": 2424.0,
+  "source_query": null,
+  "user_permission": "owner",
+  "metadata": null
+}
+```
+
+> [!NOTE]
+> File IDs are validated before creation. Invalid IDs are skipped, and the dataset is created with the valid files. If no valid file IDs are provided, the request returns 400.
+
+---
+
+## Listing Datasets
+
+```
+GET /api/v1/datasets
+```
+
+Returns a paginated list of datasets the current user can access.
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `page` | integer | `1` | Page number |
+| `page_size` | integer | `20` | Items per page (1--100) |
+| `owned_only` | boolean | `false` | Show only datasets you own |
+
+### Example
+
+```bash
+curl -s "http://localhost:8000/api/v1/datasets?page=1&page_size=10" \
+  -H "Authorization: Bearer $TOKEN" | jq
+```
+
+### Response (200 OK)
+
+```json
+{
+  "datasets": [ ... ],
+  "total_count": 42,
+  "page": 1,
+  "page_size": 10,
+  "total_pages": 5,
+  "has_next": true,
+  "has_previous": false
+}
+```
+
+Admin users see all datasets by default. Use `owned_only=true` to filter to only your own.
+
+---
+
+## Get Dataset Details
+
+```
+GET /api/v1/datasets/{dataset_id}
+```
+
+Returns full details for a specific dataset. Requires at least READ permission.
+
+```bash
+curl -s "http://localhost:8000/api/v1/datasets/f47ac10b-58cc-4372-a567-0e02b2c3d479" \
+  -H "Authorization: Bearer $TOKEN" | jq
+```
+
+---
+
+## Update a Dataset
+
+```
+PATCH /api/v1/datasets/{dataset_id}
+```
+
+Updates dataset metadata. Requires ADMIN permission or ownership.
+
+```bash
+curl -X PATCH "http://localhost:8000/api/v1/datasets/f47ac10b-58cc-4372-a567-0e02b2c3d479" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Q4 Financial Reports (Updated)",
+    "is_public": true,
+    "expires_at": "2026-12-31T23:59:59Z"
+  }'
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | New name (1--255 characters) |
+| `description` | string | New description |
+| `is_public` | boolean | Change visibility |
+| `acl_override_enabled` | boolean | Change ACL override setting |
+| `expires_at` | datetime | Change expiration date |
+
+All fields are optional. At least one must be provided.
+
+---
+
+## Delete a Dataset
+
+```
+DELETE /api/v1/datasets/{dataset_id}
+```
+
+Permanently deletes a dataset and all its items and shares. Only the dataset owner can delete it.
+
+```bash
+curl -X DELETE "http://localhost:8000/api/v1/datasets/f47ac10b-58cc-4372-a567-0e02b2c3d479" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+Returns 204 No Content on success.
+
+---
+
+## Managing Items
+
+### Add Files to a Dataset
+
+```
+POST /api/v1/datasets/{dataset_id}/items
+```
+
+Adds files to an existing dataset. Requires WRITE permission.
+
+```bash
+curl -X POST "http://localhost:8000/api/v1/datasets/f47ac10b.../items" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "file_ids": ["x1y2z3...", "a4b5c6..."],
+    "notes": "Added from latest crawl"
+  }'
+```
+
+**Response (200 OK):**
+
+```json
+{
+  "added": 2,
+  "dataset_id": "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+}
+```
+
+### List Items in a Dataset
+
+```
+GET /api/v1/datasets/{dataset_id}/items
+```
+
+Returns a paginated list of files in the dataset. Requires READ permission.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `page` | integer | `1` | Page number |
+| `page_size` | integer | `100` | Items per page (1--1000) |
+
+```bash
+curl -s "http://localhost:8000/api/v1/datasets/f47ac10b.../items?page=1&page_size=50" \
+  -H "Authorization: Bearer $TOKEN" | jq
+```
+
+Each item includes the file's name, path, UNC path, share, size, type, modification time, and when it was added to the dataset.
+
+> [!NOTE]
+> Unless ACL override is enabled, file-level access controls are enforced -- users only see items they have permission to access on the underlying share.
+
+### Remove Files from a Dataset
+
+```
+DELETE /api/v1/datasets/{dataset_id}/items
+```
+
+Removes files from a dataset. Requires WRITE permission. The files themselves are not deleted from the share.
+
+```bash
+curl -X DELETE "http://localhost:8000/api/v1/datasets/f47ac10b.../items" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"file_ids": ["x1y2z3..."]}'
+```
+
+---
+
+## Searching Within a Dataset
+
+### Full-Text Search
+
+```
+POST /api/v1/datasets/{dataset_id}/search
+```
+
+Searches the extracted content of files within a dataset. Requires READ permission.
+
+```bash
+curl -X POST "http://localhost:8000/api/v1/datasets/f47ac10b.../search" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "revenue forecast Q4",
+    "file_types": ["pdf", "xlsx"],
+    "sort_by": "relevance",
+    "page_size": 25
+  }'
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `query` | string | *(required)* | Search query (1--500 characters). Supports AND, OR, NOT operators and quoted phrases |
+| `file_types` | array | `null` | Filter by file extension (e.g., `["pdf", "docx"]`) |
+| `page` | integer | `1` | Page number |
+| `page_size` | integer | `100` | Items per page (1--1000) |
+| `sort_by` | string | `"relevance"` | Sort by: `relevance`, `modified_time`, `filename`, or `size` |
+| `sort_order` | string | `"desc"` | Sort direction: `asc` or `desc` |
+
+**Response** includes relevance scores, content snippets with highlighted matches, and full file metadata.
+
+### Named Entity Search
+
+```
+POST /api/v1/datasets/{dataset_id}/ner-search
+```
+
+Searches for named entities (people, organizations, locations, etc.) identified by the [NER service](m-ner) within a dataset. Requires READ permission.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `q` | string | *(required)* | Entity search term |
+| `entity_type` | string | `null` | Filter by entity type (e.g., `PERSON`, `ORG`) |
+| `match_mode` | string | `"substring"` | Match mode: `substring`, `exact`, or `prefix` |
+| `limit` | integer | `20` | Results per page (1--200) |
+| `cursor` | string | `null` | Pagination cursor from previous response |
+
+```bash
+curl -X POST "http://localhost:8000/api/v1/datasets/f47ac10b.../ner-search?q=NetApp&entity_type=ORG&match_mode=prefix" \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+---
+
+## Creating Subsets
+
+```
+POST /api/v1/datasets/{dataset_id}/subset
+```
+
+Creates a new dataset from a filtered subset of an existing one. Requires READ permission on the source dataset.
+
+```bash
+curl -X POST "http://localhost:8000/api/v1/datasets/f47ac10b.../subset" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Q4 PDFs Only",
+    "description": "PDF subset of Q4 reports",
+    "file_ids": ["a1b2c3...", "d4e5f6..."]
+  }'
+```
+
+The file IDs must belong to the source dataset. The new dataset is owned by the calling user with its own expiration and sharing settings.
+
+---
+
+## Sharing Datasets
+
+### Share with a User or Group
+
+```
+POST /api/v1/datasets/{dataset_id}/shares
+```
+
+Shares a dataset with a local user, Entra ID user, or Entra ID group. Requires ADMIN permission or ownership.
+
+```bash
+curl -X POST "http://localhost:8000/api/v1/datasets/f47ac10b.../shares" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "analyst01",
+    "permission": "read",
+    "expires_at": "2026-08-01T00:00:00Z"
+  }'
+```
+
+Exactly one share target must be specified:
+
+| Target | Description |
+|--------|-------------|
+| `user_id` | Local user ID |
+| `username` | Local username (resolved to user ID) |
+| `entra_user_id` | Microsoft Entra user object ID |
+| `entra_group_id` | Microsoft Entra group object ID |
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `permission` | string | `"read"` | Permission level: `read`, `write`, or `admin` |
+| `expires_at` | datetime | `null` | Optional share expiration |
+
+#### Share with an Entra ID Group
+
+```bash
+curl -X POST "http://localhost:8000/api/v1/datasets/f47ac10b.../shares" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "entra_group_id": "12345678-abcd-1234-abcd-123456789012",
+    "permission": "write"
+  }'
+```
+
+### List Shares
+
+```
+GET /api/v1/datasets/{dataset_id}/shares
+```
+
+Returns all active shares for a dataset. Requires ADMIN permission or ownership.
+
+```bash
+curl -s "http://localhost:8000/api/v1/datasets/f47ac10b.../shares" \
+  -H "Authorization: Bearer $TOKEN" | jq
+```
+
+### Update a Share
+
+```
+PATCH /api/v1/datasets/{dataset_id}/shares/{share_id}
+```
+
+Updates the permission level or expiration of a share. Requires ADMIN permission or ownership.
+
+```bash
+curl -X PATCH "http://localhost:8000/api/v1/datasets/f47ac10b.../shares/abc123..." \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"permission": "admin"}'
+```
+
+### Revoke a Share
+
+```
+DELETE /api/v1/datasets/{dataset_id}/shares/{share_id}
+```
+
+Revokes access for a specific share. Returns 204 No Content.
+
+```bash
+curl -X DELETE "http://localhost:8000/api/v1/datasets/f47ac10b.../shares/abc123..." \
+  -H "Authorization: Bearer $TOKEN"
+```
+
+---
+
+## ACL Override
+
+By default, when users list or search items in a dataset, file-level access controls from the underlying storage are enforced. Users only see files they have permission to access on the original share.
+
+When **ACL override** is enabled on a dataset, shared users can access all items regardless of file-level permissions. This is useful when you want to share a curated collection without requiring users to have direct access to the underlying shares.
+
+> [!WARNING]
+> Enabling ACL override grants access to file content that users may not have permission to view at the storage level. All override access is recorded in the audit log for compliance review.
+
+**Enable ACL override on creation:**
+
+```bash
+curl -X POST http://localhost:8000/api/v1/datasets \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Cross-Team Research",
+    "file_ids": ["..."],
+    "acl_override_enabled": true
+  }'
+```
+
+**Enable ACL override on an existing dataset:**
+
+```bash
+curl -X PATCH "http://localhost:8000/api/v1/datasets/f47ac10b..." \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"acl_override_enabled": true}'
+```
+
+---
+
+## Expiration
+
+Datasets expire automatically to prevent stale data collections from accumulating.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| Default expiration | 90 days | Applied when `expires_at` is not specified |
+| Custom expiration | -- | Set via `expires_at` on create or update |
+| Countdown warnings | 10 days before | Logged daily, then hourly on the final day |
+| Auto-deletion | On expiry | Dataset, items, and shares are automatically removed |
+
+The default expiration period is configurable via the `DATASET_DEFAULT_EXPIRATION_DAYS` environment variable.
+
+### Monitoring Expiring Datasets
+
+Administrators can query for datasets nearing expiration:
+
+```bash
+curl -s "http://localhost:8000/api/v1/datasets/expiring?within_hours=240" \
+  -H "Authorization: Bearer $TOKEN" | jq
+```
+
+This returns all datasets expiring within the specified window (default 240 hours / 10 days). Requires admin access.
+
+---
+
+## Rate Limiting
+
+Dataset operations are rate-limited per user to protect system resources:
+
+| Operation | Default Limit | Environment Variable |
+|-----------|--------------|---------------------|
+| Create / subset | 10 per minute | `DATASET_RATE_LIMIT_CREATE` |
+| Search (text and NER) | 20 per minute | `DATASET_RATE_LIMIT_SEARCH` |
+| Item operations (add/remove/list) | 30 per minute | `DATASET_RATE_LIMIT_ITEMS` |
+
+When a rate limit is exceeded, the API returns HTTP 429 with a `Retry-After` header.
+
+---
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `DATASET_DEFAULT_EXPIRATION_DAYS` | `90` | Default dataset lifetime in days |
+| `DATASET_RATE_LIMIT_CREATE` | `10` | Max create operations per user per minute |
+| `DATASET_RATE_LIMIT_SEARCH` | `20` | Max search operations per user per minute |
+| `DATASET_RATE_LIMIT_ITEMS` | `30` | Max item operations per user per minute |
+
+---
+
+## API Reference
+
+| Method | Endpoint | Description | Permission |
+|--------|----------|-------------|------------|
+| `POST` | `/api/v1/datasets` | Create a dataset | Authenticated |
+| `GET` | `/api/v1/datasets` | List accessible datasets | Authenticated |
+| `GET` | `/api/v1/datasets/expiring` | List expiring datasets | Admin |
+| `GET` | `/api/v1/datasets/{id}` | Get dataset details | READ |
+| `PATCH` | `/api/v1/datasets/{id}` | Update dataset metadata | ADMIN / Owner |
+| `DELETE` | `/api/v1/datasets/{id}` | Delete dataset | Owner |
+| `POST` | `/api/v1/datasets/{id}/items` | Add files to dataset | WRITE |
+| `GET` | `/api/v1/datasets/{id}/items` | List files in dataset | READ |
+| `DELETE` | `/api/v1/datasets/{id}/items` | Remove files from dataset | WRITE |
+| `POST` | `/api/v1/datasets/{id}/search` | Full-text search within dataset | READ |
+| `POST` | `/api/v1/datasets/{id}/ner-search` | Named entity search within dataset | READ |
+| `POST` | `/api/v1/datasets/{id}/subset` | Create a subset dataset | READ |
+| `POST` | `/api/v1/datasets/{id}/shares` | Share dataset | ADMIN / Owner |
+| `GET` | `/api/v1/datasets/{id}/shares` | List shares | ADMIN / Owner |
+| `PATCH` | `/api/v1/datasets/{id}/shares/{share_id}` | Update share | ADMIN / Owner |
+| `DELETE` | `/api/v1/datasets/{id}/shares/{share_id}` | Revoke share | ADMIN / Owner |
+
+---
+
+## Error Responses
+
+| Status | Meaning |
+|--------|---------|
+| 400 | Invalid request (no valid file IDs, missing required fields, validation errors) |
+| 401 | Authentication required |
+| 403 | Insufficient permission |
+| 404 | Dataset or share not found |
+| 429 | Rate limit exceeded (check `Retry-After` header) |
+| 501 | PostgreSQL required (MySQL not supported) |

--- a/docs/projects/mlai/neo/core/m-extraction.md
+++ b/docs/projects/mlai/neo/core/m-extraction.md
@@ -23,7 +23,7 @@ The **extractor service** is the component responsible for reading files from mo
 - **Full-text search** -- users can search across all indexed file content via the API or MCP tools.
 - **Named Entity Recognition (NER)** -- the NER service processes extracted text to identify entities such as people, organizations, addresses, financial data, and personally identifiable information (PII).
 
-The extractor service runs as an independent microservice that pulls work items from a shared queue. It supports CPU-only and GPU-accelerated modes, with optional Vision Language Model (VLM) pipelines for scanned and image-heavy documents.
+The extractor service runs as an independent microservice. It supports CPU-only and GPU-accelerated modes, with optional Vision Language Model (VLM) pipelines for scanned and image-heavy documents.
 
 ---
 
@@ -81,33 +81,15 @@ Operates in two modes:
 
 ## Intelligent Routing & Fallback Chain
 
-The extractor service uses a **strategy router** (`ExtractionStrategy`) that selects the best backend based on file extension and file size. If the primary extractor fails, the service automatically falls back to the next extractor in the chain.
-
-### Routing Rules
-
-| File Type | Small Files | Large Files | Threshold |
-|-----------|------------|-------------|-----------|
-| **Plain text / source code** | TextExtractor | TextExtractor | -- |
-| **PDF** | MarkItDown, then Docling | Docling, then MarkItDown | 1 MB |
-| **Office** (`.docx`, `.xlsx`, `.pptx`, etc.) | MarkItDown, then Docling | Docling, then MarkItDown | 2 MB |
-| **Images** (`.jpg`, `.png`, `.tiff`, etc.) | MarkItDown, then Docling | Docling, then MarkItDown | 512 KB |
-| **Markup** (`.html`, `.xml`, etc.) | TextExtractor, then Docling | Docling, then TextExtractor | 5 MB |
-| **Unknown extensions** | MarkItDown, then Docling | MarkItDown, then Docling | -- |
+The extractor service automatically selects the best extraction backend based on file type and characteristics. If the primary extractor fails or returns empty content, the service falls back to the next available backend in the chain.
 
 **How it works:**
 
 1. The strategy router examines the file extension and size.
-2. It returns an ordered list of extractors to try.
-3. The service attempts the first extractor. If it fails or returns empty content, it tries the next one.
-4. For small PDFs and Office files, MarkItDown is tried first because it is faster. For large files, Docling is preferred because it handles complex layouts and large documents more reliably.
+2. It selects the most appropriate backend and identifies fallback alternatives.
+3. If the primary extractor fails, it automatically retries with the next backend in the chain.
 
-### Example
-
-A 3 MB PDF file:
-1. File size (3 MB) exceeds the PDF threshold (1 MB).
-2. Strategy returns: `["docling", "markitdown"]`.
-3. Docling attempts extraction with OCR and table recognition.
-4. If Docling fails (e.g., not installed), MarkItDown handles it as a fallback.
+Plain text files are always handled by the TextExtractor. For binary formats (PDFs, Office documents, images), the router selects between MarkItDown and Docling based on file characteristics, ensuring the fastest and most reliable extraction for each document.
 
 ---
 
@@ -117,33 +99,22 @@ The Docling VLM pipeline supports multiple Vision Language Models. Based on [ben
 
 ### Working Models
 
-| Model Spec | HuggingFace Repo | Output Format | VRAM Required | Notes |
-|------------|------------------|---------------|---------------|-------|
-| `GRANITEDOCLING_TRANSFORMERS` | `ibm-granite/granite-docling-258M` | DOCTAGS | ~5 GB peak | **Recommended.** Best extraction quality on scanned documents. 3.4x more content than OCR baseline on image-heavy PDFs with zero OCR artifacts. |
-| `SMOLDOCLING_TRANSFORMERS` | `docling-project/SmolDocling-256M-preview` | DOCTAGS | ~3 GB peak | Smaller and faster, but produces hallucinated output on multi-page structured forms. Not recommended for complex documents. |
-
-### Models Requiring Specific Hardware or Software
-
-| Model Spec | HuggingFace Repo | VRAM Required | Status |
-|------------|------------------|---------------|--------|
-| `GOT2_TRANSFORMERS` | `stepfun-ai/GOT-OCR-2.0-hf` | ~1.5 GB | Blocked by SDPA attention incompatibility in transformers 4.57+. |
-| `DOLPHIN_TRANSFORMERS` | `ByteDance/Dolphin` | ~2 GB | Same SDPA issue as GOT2. |
-| `GRANITE_VISION_TRANSFORMERS` | `ibm-granite/granite-vision-3.2-2b` | ~4 GB | Requires isolated GPU process; OOMs when sharing VRAM with other models. |
-| `PHI4_TRANSFORMERS` | `microsoft/Phi-4-multimodal-instruct` | ~8 GB | Requires `transformers<4.52.0`. |
-| `PIXTRAL_12B_TRANSFORMERS` | `mistral-community/pixtral-12b` | ~24 GB | Requires high-end GPU (A100, H100, or multi-GPU). |
+| Model Spec | VRAM Required | Notes |
+|------------|---------------|-------|
+| `GRANITEDOCLING_TRANSFORMERS` | ~5 GB peak | **Recommended.** Best extraction quality on scanned documents with minimal OCR artifacts. |
+| `SMOLDOCLING_TRANSFORMERS` | ~3 GB peak | Smaller and faster, but may produce lower quality output on multi-page structured forms. |
 
 ### When to Use VLM vs Standard OCR
 
 | Document Type | Recommended Pipeline | Reason |
 |---------------|---------------------|--------|
-| Scanned/image-heavy PDFs | Docling VLM (Granite-Docling) | 3.4x better content extraction than OCR on scanned pages |
-| Text-native PDFs and forms | Standard Docling OCR | 5x more content on structured forms, 25x faster |
+| Scanned/image-heavy PDFs | Docling VLM (Granite-Docling) | Superior content extraction on scanned pages |
+| Text-native PDFs and forms | Standard Docling OCR | Faster processing with good results on structured forms |
 | Office documents | MarkItDown | Native format conversion, no GPU needed |
 | Plain text / source code | TextExtractor | Direct read, fastest |
 
-::: warning Performance Trade-off
-VLM extraction is approximately 25x slower than the standard OCR pipeline. Granite-Docling averaged 5 minutes 49 seconds per document vs 14 seconds for OCR baseline in benchmarks. Use VLM only when standard extraction produces poor results.
-:::
+> [!NOTE]
+> VLM extraction produces significantly better results on scanned documents but is considerably slower than the standard OCR pipeline. Use VLM only when standard extraction produces poor results.
 
 ---
 
@@ -221,24 +192,9 @@ docker cp $(docker compose ps -q extractor):/tmp/vlm_benchmark_results.json .
 
 ### What It Measures
 
-For each VLM model and each test document, the benchmark records:
+For each VLM model and each test document, the benchmark records extraction completeness, content quality metrics, processing time, and GPU memory usage. The standard Docling OCR pipeline is included as a baseline for comparison.
 
-- **Word count** and **character count** -- measures extraction completeness.
-- **Long words** (>30 characters) -- detects OCR artifacts where spaces between words are missed.
-- **Repeated lines** -- detects hallucination patterns where models emit repeated sequences.
-- **Image placeholder count** -- counts image tags in output.
-- **Extraction time** -- wall-clock duration.
-- **Peak VRAM usage** -- GPU memory consumption.
-- **Content sample** -- first 500 characters for manual quality inspection.
-
-The standard Docling OCR pipeline is included as a baseline for comparison.
-
-### Interpreting Results
-
-- High word count with low long-word count indicates clean, complete extraction.
-- Low word count relative to baseline suggests the model missed content.
-- High repeated-line count indicates hallucination (the model generates plausible-looking but fabricated text).
-- Results are saved as JSON for programmatic analysis.
+Results are saved as JSON for programmatic analysis.
 
 ---
 
@@ -254,28 +210,11 @@ POST /shares/{share_id}/recrawl-missing-content
 
 **Authentication:** Requires a valid user token.
 
-### What It Does
-
-The endpoint identifies files with missing content in two categories:
-
-1. **NULL content** -- files that have metadata records but the content field is NULL (extraction started but failed).
-2. **Unextracted files** -- files in the inventory that are stuck in `discovered` status with no metadata at all (extraction was never attempted).
-
-For each identified file, the endpoint:
-
-1. Deletes any stale metadata records (for NULL content files).
-2. Resets the file inventory status so extraction can be reattempted.
-3. Queues new extraction work items at priority 3.
-4. Sets the share status back to `PROCESSING`.
+The endpoint identifies files with incomplete or missing extracted content and re-queues them for processing.
 
 ### Example
 
 ```bash
-# Get an auth token
-TOKEN=$(curl -s -X POST http://localhost:8000/token \
-  -d "username=admin&password=yourpassword" | jq -r .access_token)
-
-# Recrawl missing content for a specific share
 curl -X POST http://localhost:8000/shares/{share_id}/recrawl-missing-content \
   -H "Authorization: Bearer $TOKEN"
 ```

--- a/docs/projects/mlai/neo/core/m-files.md
+++ b/docs/projects/mlai/neo/core/m-files.md
@@ -187,7 +187,7 @@ curl -s "http://localhost:8000/api/v1/files?file_type=pdf&page_size=50&field_set
 POST /api/v1/search
 ```
 
-Searches across extracted file content using database-native full-text search. On PostgreSQL, this uses a GIN-indexed `search_vector` column that provides 20--42x faster queries compared to pattern-based search. Results include relevance scoring and content snippets.
+Searches across extracted file content using database-native full-text search. On PostgreSQL, this uses optimized full-text indexes for high-performance queries. Results include relevance scoring and content snippets.
 
 ### Request Body
 
@@ -254,9 +254,8 @@ curl -s -X POST "http://localhost:8000/api/v1/search" \
 }
 ```
 
-::: tip Performance
-The GIN-indexed `search_vector` column on PostgreSQL delivers 20--42x faster full-text search compared to `LIKE`/`ILIKE` pattern matching. No additional configuration is required -- the index is created automatically during database initialization.
-:::
+> [!TIP]
+> PostgreSQL deployments benefit from optimized full-text search indexes that are created automatically during database initialization. No additional configuration is required.
 
 ## Field Selection
 
@@ -341,7 +340,7 @@ pending --> processing --> completed
 
 1. **Pending** -- The file has been discovered during a share crawl and queued for content extraction.
 2. **Processing** -- A worker has claimed the file and the extractor service is converting it to text.
-3. **Completed** -- Content extraction succeeded. The file's `content` field is populated and the `search_vector` index is updated.
+3. **Completed** -- Content extraction succeeded. The file's content is stored and the search index is updated.
 4. **Error** -- Extraction failed. The work queue retries the file automatically (default: up to 3 retries). Persistent failures are logged with an error message.
 
 Once a file reaches the **completed** state, it is available for full-text search and its metadata is visible in all listing endpoints.

--- a/docs/projects/mlai/neo/core/m-mcp.md
+++ b/docs/projects/mlai/neo/core/m-mcp.md
@@ -117,13 +117,11 @@ The MCP integration allows AI assistants to securely search and retrieve content
 │                                                                              │
 └──────────────────────────────────────────────────────────────────────────────┘
                                │
-                               │ Internal HTTP
+                               │ Internal
                                ▼
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │                        NETAPP CONNECTOR API                                  │
-│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────────────┐  │
-│  │ GET /files  │  │ POST /search│  │ GET /shares │  │ GET /ner/entities   │  │
-│  └─────────────┘  └─────────────┘  └─────────────┘  └─────────────────────┘  │
+│           Files, Search, Shares, NER, and Virtual Datasets                   │
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -383,7 +381,7 @@ The MCP server exposes five tools for AI agents:
 
 ### 1\. `search_files`
 
-Search for files by name, type, date, or size across all accessible shares. Uses GIN-indexed `search_vector` for 20-42x faster full-text search (PostgreSQL).
+Search for files by name, type, date, or size across all accessible shares. Leverages optimized full-text search indexes for high-performance queries (PostgreSQL).
 
 **Parameters:**
 

--- a/docs/projects/mlai/neo/core/m-ner.md
+++ b/docs/projects/mlai/neo/core/m-ner.md
@@ -1,17 +1,16 @@
 # Named Entity Recognition (NER)
 
-Project Neo uses [GLiNER2](https://github.com/urchade/GLiNER) (Generalist and Lightweight model for Named Entity Recognition) to identify and extract structured entities from document text. NER runs as a dedicated microservice (`ner_service`) and processes files asynchronously via the worker queue after text extraction completes.
+Project Neo uses Named Entity Recognition (NER) to identify and extract structured entities from document text. NER runs as a dedicated microservice and processes files asynchronously after text extraction completes.
 
 ## How It Works
 
 1. A file is uploaded to a share that has `enable_ner_analysis` turned on.
-2. The worker service extracts text from the file (PDF, DOCX, etc.).
-3. The worker sends the extracted text to the NER service over an internal HTTP call.
-4. The NER service runs the GLiNER2 model against the text using the share's configured schema.
-5. Detected entities, classifications, and structured extractions are stored in PostgreSQL.
-6. Results are available immediately through the API.
+2. Neo extracts text from the file (PDF, DOCX, etc.).
+3. The NER service analyses the extracted text using the share's configured schema.
+4. Detected entities, classifications, and structured extractions are stored in the database.
+5. Results are available immediately through the API.
 
-The underlying model is **DeBERTa-v3-base** fine-tuned for zero-shot NER. It accepts a list of target entity labels and returns spans with confidence scores -- no task-specific training is needed.
+The NER engine uses zero-shot recognition -- it accepts a list of target entity labels and returns spans with confidence scores, so no task-specific training is needed.
 
 ## NER Schemas
 
@@ -132,17 +131,8 @@ The NER service is configured through environment variables set on the `ner` con
 | `NER_MODEL_NAME` | `fastino/gliner2-base-v1` | Hugging Face model identifier. The model is downloaded on first startup. |
 | `NER_CONFIDENCE_THRESHOLD` | `0.7` | Global minimum confidence score (0.0--1.0). Per-share thresholds override this. |
 | `NER_DEVICE` | `auto` | Compute device: `auto`, `cuda`, or `cpu`. `auto` selects CUDA when a GPU is detected. |
-| `NER_MAX_TEXT_LENGTH` | `8000` | Maximum characters per chunk sent to the model. GLiNER2 has a 2048-token context window (~4 chars/token = ~8000 chars). |
-| `NER_CUDA_MAX_TEXT_LENGTH` | `8000` | Hard cap on chunk size when running on CUDA to prevent out-of-memory errors. |
-| `NER_CHUNK_OVERLAP` | `500` | Character overlap between adjacent chunks so entities at boundaries are not missed. |
-| `NER_TOKEN_BUDGET` | `2048` | Token budget per chunk for the tokenizer-aware chunking path. |
-| `NER_MAX_BATCH_SIZE` | `32` | Upper limit for adaptive batch sizing on GPU. |
-| `NER_ESTIMATED_MB_PER_CHUNK` | `1500` | Estimated VRAM (MB) per chunk, used for initial batch size calculation before probing. |
+| `NER_MAX_BATCH_SIZE` | `32` | Upper limit for batch sizing on GPU. Reduce if you encounter out-of-memory errors. |
 | `NER_CPU_BATCH_SIZE` | `16` | Fixed batch size when running on CPU. |
-| `NER_BATCH_RECOVERY_INTERVAL` | `50` | Number of successful inferences before attempting to increase batch size after an OOM. |
-| `NER_MAX_CONSECUTIVE_OOMS` | `3` | After this many consecutive OOM errors, the engine falls back to CPU. |
-| `NER_CUDA_RETRY_COOLDOWN` | `200` | Number of successful CPU inferences before retrying CUDA after an OOM fallback. |
-| `NER_MAX_CUDA_RETRIES` | `3` | Maximum number of times to retry moving back to CUDA after OOM fallback. |
 
 ## Per-Share NER Settings
 
@@ -344,20 +334,15 @@ Set `NER_DEVICE=auto` (the default) to let the engine detect available hardware.
 
 ### Text Chunking
 
-GLiNER2 is based on DeBERTa-v3-base with a 2048-token context window. For documents longer than the context window, the engine splits text into chunks of up to `NER_MAX_TEXT_LENGTH` characters with `NER_CHUNK_OVERLAP` characters of overlap between adjacent chunks. Entity spans detected across chunk boundaries are deduplicated in post-processing.
+For documents longer than the model's context window, the engine automatically splits text into manageable chunks with overlap between adjacent chunks. Entity spans detected across chunk boundaries are deduplicated in post-processing.
 
 ### Adaptive Batch Sizing
 
-On GPU, the engine probes available VRAM at startup and computes an initial batch size. During inference:
-
-- Successful batches gradually increase the batch size up to `NER_MAX_BATCH_SIZE`.
-- An OOM error halves the batch size and retries.
-- After `NER_MAX_CONSECUTIVE_OOMS` consecutive OOM errors, the engine falls back to CPU automatically.
-- After `NER_CUDA_RETRY_COOLDOWN` successful CPU inferences, the engine attempts to move back to CUDA (up to `NER_MAX_CUDA_RETRIES` times).
+On GPU, the engine automatically adapts batch sizes to the available VRAM. If out-of-memory errors occur, the batch size is reduced and processing continues. If GPU memory issues persist, the engine falls back to CPU automatically and will attempt to return to GPU after a cooldown period.
 
 ### VRAM Requirements
 
-The GLiNER2 base model requires approximately 500 MB of VRAM. Each inference chunk uses an estimated `NER_ESTIMATED_MB_PER_CHUNK` MB (default 1500 MB) for activations and gradients. A GPU with 4 GB of VRAM can comfortably run batch size 1--2; 8 GB or more is recommended for larger batch sizes.
+A GPU with 4 GB of VRAM is sufficient for small batch sizes. 8 GB or more is recommended for production workloads with larger batch sizes.
 
 ## Troubleshooting
 
@@ -387,12 +372,6 @@ Actions:
 - If the GPU has limited VRAM (less than 4 GB), set `NER_DEVICE=cpu` to avoid OOM entirely.
 
 The engine automatically falls back to CPU after repeated OOMs and will attempt to return to CUDA after a cooldown period.
-
-### Tokenizer Deadlock
-
-The Hugging Face `tokenizers` library uses Rust-based parallelism that can deadlock when called from multiple Python threads inside a forked process. Symptoms: the NER service hangs during inference with no log output.
-
-Workaround: Set the environment variable `TOKENIZERS_PARALLELISM=false` on the NER container. This disables tokenizer-level parallelism and prevents the deadlock. The Neo container images set this by default.
 
 ### NER Results Are Empty
 

--- a/docs/projects/mlai/neo/core/m-performance.md
+++ b/docs/projects/mlai/neo/core/m-performance.md
@@ -23,10 +23,10 @@ Neo includes a 5-stage benchmark pipeline that measures throughput, latency, and
 
 | Stage | What It Measures |
 |---|---|
-| **Database** | Read query throughput and latency against `file_inventory` |
+| **Database** | Read query throughput and latency |
 | **Enumeration** | File discovery and directory scanning performance |
-| **Extraction** | Content extraction throughput from historical completed work items |
-| **ACL Extraction** | ACL/permission resolution throughput from completed ACL work items |
+| **Extraction** | Content extraction throughput |
+| **ACL Extraction** | ACL/permission resolution throughput |
 | **Graph Upload** | Microsoft Graph API upload throughput, including rate-limit detection |
 
 ### Metrics Per Stage
@@ -41,13 +41,7 @@ Each stage reports:
 
 ### Bottleneck Detection
 
-After all stages complete, the system identifies the stage with the lowest throughput as the pipeline bottleneck. Recommendations are then generated targeting the bottleneck:
-
-- **Extraction bottleneck**: Increase `NUM_EXTRACTION_WORKERS` or `CONTENT_EXTRACTION_PARALLEL_WORKERS`
-- **Graph upload bottleneck**: Adjust `NUM_UPLOAD_WORKERS` or `GRAPH_RATE_LIMIT` (reduce rate if 429 throttling is active)
-- **Database bottleneck**: Increase `DATABASE_BATCH_INSERT_SIZE` or `DATABASE_CONNECTION_POOL_SIZE`
-- **ACL extraction bottleneck**: Increase `MAX_CONCURRENT_WORK`
-- **Enumeration bottleneck**: Increase `MAX_ENUMERATION_WORKERS`
+After all stages complete, the system identifies the stage with the lowest throughput as the pipeline bottleneck and generates tuning recommendations. The auto-tuner suggests parameter adjustments targeting the specific bottleneck stage, such as increasing worker counts, adjusting batch sizes, or modifying rate limits.
 
 ---
 
@@ -163,12 +157,12 @@ curl http://localhost:8000/api/v1/monitoring/benchmark/history \
 
 Neo ships with four sizing profiles based on file estate size. The system auto-detects the appropriate profile by examining available CPU and RAM.
 
-| Profile | File Estate | CPU | RAM | Extraction Workers | Upload Workers | Graph Rate Limit |
-|---|---|---|---|---|---|---|
-| **Small** | < 10K files | 2 cores | 4 GB | 1 | 2 | 20 req/s |
-| **Medium** | 10K - 100K files | 4 cores | 8 GB | 2 | 3 | 25 req/s |
-| **Large** | 100K - 1M files | 8 cores | 16 GB | 4 | 6 | 40 req/s |
-| **Enterprise** | > 1M files | 16 cores | 32 GB | 8 | 10 | 50 req/s |
+| Profile | File Estate | Recommended CPU | Recommended RAM |
+|---|---|---|---|
+| **Small** | < 10K files | 2 cores | 4 GB |
+| **Medium** | 10K - 100K files | 4 cores | 8 GB |
+| **Large** | 100K - 1M files | 8 cores | 16 GB |
+| **Enterprise** | > 1M files | 16+ cores | 32+ GB |
 
 ### Get All Profiles
 
@@ -302,69 +296,19 @@ curl http://localhost:8000/api/v1/monitoring/tuning/status \
 
 ## Manual Tuning
 
-The following environment variables control Neo's performance characteristics. Set them in your Docker Compose file, Kubernetes deployment, or container runtime environment.
+Neo exposes a comprehensive set of environment variables for manual tuning. Set them in your Docker Compose file, Kubernetes deployment, or container runtime environment.
 
-### Worker Concurrency
+Key tuning categories include:
 
-| Variable | Default | Description |
-|---|---|---|
-| `NUM_EXTRACTION_WORKERS` | 1 | Number of extraction worker processes. Scale with available CPU cores (max 16). Requires restart. |
-| `NUM_UPLOAD_WORKERS` | 3 | Number of Graph upload worker tasks. Scale with network bandwidth (max 16). Requires restart. |
-| `EXTRACTION_THREAD_POOL_SIZE` | 0 (auto) | Thread pool size per extraction worker. 0 = auto-detect from CPU count (max 32). Requires restart. |
-| `MAX_CONCURRENT_WORK` | 10 | Maximum concurrent work items per worker. Higher = more parallelism but more memory pressure (max 50). Safe to adjust at runtime. |
-| `CONTENT_EXTRACTION_PARALLEL_WORKERS` | 4 | Parallel threads within a single extraction work item for multi-page documents (max 16). Safe to adjust at runtime. |
+- **Worker concurrency** -- control the number of extraction workers, upload workers, and parallel threads
+- **Enumeration** -- adjust directory scanning parallelism and strategies for large file estates
+- **Batch sizes** -- optimize database insert and work queue batch sizes for throughput
+- **Microsoft Graph rate limiting** -- balance upload speed against API throttling
+- **Timeouts** -- configure processing, extraction, and upload timeouts
+- **Database** -- adjust connection pool sizes and query timeouts
+- **Content extraction** -- set maximum file sizes and content chunking thresholds
 
-### Enumeration
-
-| Variable | Default | Description |
-|---|---|---|
-| `MAX_ENUMERATION_WORKERS` | 4 | Parallel directory scanning workers (max 16). Safe to adjust at runtime. |
-| `ENUMERATION_STRATEGY` | `auto` | Scanning strategy: `auto`, `directory_parallel`, `depth_parallel`, `hybrid`, `single_worker`. |
-| `ENUMERATION_TIMEOUT` | 3600 | Maximum seconds for a full share enumeration. Increase for very large shares. |
-| `MAX_DEPTH_PER_WORKER` | 3 | Maximum directory depth each enumeration worker processes. |
-
-### Batch Sizes
-
-| Variable | Default | Description |
-|---|---|---|
-| `DIRECTORY_BATCH_SIZE` | 100 | Directories processed per batch during enumeration (max 1000). |
-| `FILE_BATCH_SIZE` | 1000 | Files inserted per database batch (max 10000). |
-| `WORK_QUEUE_BATCH_SIZE` | 50 | Work items created per batch (max 500). |
-| `DATABASE_BATCH_INSERT_SIZE` | 500 | General database batch insert size (max 5000). |
-
-### Microsoft Graph Rate Limiting
-
-| Variable | Default | Description |
-|---|---|---|
-| `GRAPH_RATE_LIMIT` | 25.0 | Requests per second to the Graph API. Higher = faster uploads but risk of 429 throttling. |
-| `GRAPH_DAILY_QUOTA` | 100000 | Maximum Graph API requests per day. |
-| `GRAPH_BACKOFF_BASE_DELAY` | 1.0 | Initial backoff delay (seconds) after a 429 response. |
-| `GRAPH_BACKOFF_MAX_DELAY` | 300.0 | Maximum backoff delay (seconds) after repeated 429s. |
-| `GRAPH_BACKOFF_MULTIPLIER` | 2.0 | Exponential backoff multiplier. |
-
-### Timeouts
-
-| Variable | Default | Description |
-|---|---|---|
-| `WORK_PROCESSING_TIMEOUT` | 7200 | Maximum seconds to process a single work item. |
-| `FILE_EXTRACTION_TIMEOUT` | 300 | Maximum seconds to extract content from a single file. |
-| `GRAPH_UPLOAD_TIMEOUT` | 120 | Maximum seconds for a single Graph API upload. |
-| `FS_SCAN_TIMEOUT_PER_DIRECTORY` | 60 | Maximum seconds to scan a single directory. |
-
-### Database
-
-| Variable | Default | Description |
-|---|---|---|
-| `DATABASE_CONNECTION_POOL_SIZE` | 10 | Connection pool size. More connections = higher DB parallelism (max 50). Requires restart. |
-| `DATABASE_QUERY_TIMEOUT` | 30 | Query timeout in seconds (max 300). Requires restart. |
-
-### Content Extraction
-
-| Variable | Default | Description |
-|---|---|---|
-| `CONTENT_EXTRACTION_MAX_SIZE` | 10 MB | Maximum file size for content extraction. Files larger than this are skipped. |
-| `CONTENT_CHUNK_SIZE` | 900 KB | Content chunk size for database storage. Content larger than this is split into multiple rows. |
-| `GRAPH_CONTENT_CHUNK_SIZE` | 3.8 MB | Maximum content size per Microsoft Graph external item. |
+Use the sizing API endpoints (`GET /api/v1/monitoring/sizing/parameters`) to retrieve the full list of tunable parameters with descriptions, defaults, and recommended values for your hardware.
 
 ---
 

--- a/docs/projects/mlai/neo/core/m-protocols.md
+++ b/docs/projects/mlai/neo/core/m-protocols.md
@@ -16,7 +16,7 @@ All protocols share a common workflow: create a share, test the connection, craw
 
 ## SMB File Shares
 
-SMB (Server Message Block), also known as CIFS, is the standard protocol for Windows file shares. Neo mounts SMB shares read-only inside the Extractor container using `mount.cifs` and enumerates files via the local mount point. ACLs are read using `smbcacls`.
+SMB (Server Message Block), also known as CIFS, is the standard protocol for Windows file shares. Neo connects to SMB shares read-only and enumerates files for indexing. ACLs are extracted and resolved to support access control.
 
 ### Supported Storage Systems
 

--- a/docs/projects/mlai/neo/core/m-search.md
+++ b/docs/projects/mlai/neo/core/m-search.md
@@ -100,20 +100,18 @@ curl -X POST http://localhost:8000/api/v1/search \
 
 #### PostgreSQL (Recommended)
 
-Neo uses PostgreSQL's GIN-indexed `search_vector` column on the `file_metadata` table for full-text search. This provides:
+Neo uses PostgreSQL's full-text search capabilities with optimized indexing for high-performance content search. This provides:
 
-- **GIN Index**: A pre-built Generalized Inverted Index over tsvector data, enabling sub-millisecond lookups even on millions of rows.
 - **Phrase Matching**: Use double-quoted phrases to match exact word sequences.
-- **Prefix Wildcards**: Partial word matching via `websearch_to_tsquery`.
+- **Prefix Matching**: Partial word matching for broader searches.
 - **Boolean Operators**: `AND`, `OR`, `NOT` logic supported in natural language queries.
-- **Relevance Ranking**: Results are scored using `ts_rank_cd` (cover density ranking) which considers proximity of matching terms.
-- **Content Snippets**: `ts_headline` generates contextual snippets around matching terms with HTML `<b>` highlighting, returning approximately 25-50 words of context per match.
-- **Chunk Deduplication**: Large files are split into chunks for extraction. The search automatically deduplicates chunks by `parent_file_id`, returning only the highest-scoring snippet per original file.
-- **Performance**: 20-42x speedup over basic `LIKE` queries, measured on real-world datasets.
+- **Relevance Ranking**: Results are scored by relevance, considering proximity of matching terms.
+- **Content Snippets**: Contextual snippets around matching terms with highlighted keywords.
+- **Deduplication**: Large files split into chunks are automatically deduplicated, returning only the best-matching snippet per original file.
 
 #### MySQL
 
-For MySQL deployments, Neo uses `FULLTEXT` indexes with two search modes:
+For MySQL deployments, Neo uses full-text indexes with two search modes:
 
 - **Natural Language Mode** (`search_mode: "natural"`): OR-based matching ranked by relevance. Best for general queries.
 - **Boolean Mode** (`search_mode: "boolean"`): AND-based matching with operators (`+`, `-`, `*`, `""`). Best for precise queries.

--- a/docs/projects/mlai/neo/core/management.md
+++ b/docs/projects/mlai/neo/core/management.md
@@ -6,6 +6,7 @@ This section covers the various ways to manage and interact with NetApp Project 
 
 - [Shares](./m-shares.md) -- Configure and manage SMB file shares
 - [Files](./m-files.md) -- Browse and manage indexed files
+- [Virtual Datasets](./m-datasets.md) -- Create, share, and search curated file collections
 - [Users](./m-users.md) -- User account management and roles
 - [ACLs](./m-acls.md) -- Access control list management
 
@@ -24,6 +25,6 @@ This section covers the various ways to manage and interact with NetApp Project 
 
 ## Interfaces
 
-- [Console](./m-console.md) -- Web-based management console (port 8081)
+- [Console](./m-console.md) -- Web-based management console
 - [API Reference](./m-api.md) -- REST API documentation and usage
 - [Performance](./m-performance.md) -- Performance monitoring and benchmarking

--- a/docs/projects/mlai/neo/core/qs-docker.md
+++ b/docs/projects/mlai/neo/core/qs-docker.md
@@ -55,8 +55,8 @@ Aside from the versioning and database paramters, Neo services can be configured
 
 ```bash
 # Neo container image versioning
-NEO_VERSION=4.0.3p7
-NUI_VERSION=3.2.2
+NEO_VERSION=4.1.4
+NUI_VERSION=4.1.0-20250513
 
 ## Database Settings (required)
 # Modify accordingly to your preferences
@@ -90,7 +90,7 @@ api-1           neo-api                                     Up 25 seconds (healt
 extractor-1     neo-extractor                               Up 28 seconds (healthy)
 ner-1           neo-ner                                     Up 28 seconds (healthy)
 worker-1        neo-worker                                  Up 20 seconds (healthy)
-neoui           ghcr.io/beezy-dev/neo-ui-framework:3.2.2   Up 18 seconds             0.0.0.0:8081->80/tcp
+neoui           ghcr.io/netapp/neo-ui-framework:4.1.0-20250513   Up 18 seconds             0.0.0.0:8081->80/tcp
 
 View logs:
 docker compose logs -f
@@ -107,7 +107,7 @@ api-1           neo-api                                     Up 25 seconds (healt
 extractor-1     neo-extractor                               Up 28 seconds (healthy)
 ner-1           neo-ner                                     Up 28 seconds (healthy)
 worker-1        neo-worker                                  Up 20 seconds (healthy)
-neoui           ghcr.io/beezy-dev/neo-ui-framework:3.2.2   Up 18 seconds             0.0.0.0:8081->80/tcp
+neoui           ghcr.io/netapp/neo-ui-framework:4.1.0-20250513   Up 18 seconds             0.0.0.0:8081->80/tcp
 
 View logs:
 sudo podman compose logs -f

--- a/docs/projects/mlai/neo/core/qs-kubernetes.md
+++ b/docs/projects/mlai/neo/core/qs-kubernetes.md
@@ -944,11 +944,11 @@ helm repo update
 helm upgrade netapp-neo innovation-labs/netapp-neo \
   --namespace netapp-neo \
   --reuse-values \
-  --set api.image.tag="4.0.2" \
-  --set worker.image.tag="4.0.2" \
-  --set extractor.image.tag="4.0.2" \
-  --set ner.image.tag="4.0.2" \
-  --set ui.image.tag="3.2.2"
+  --set api.image.tag="4.1.4" \
+  --set worker.image.tag="4.1.4" \
+  --set extractor.image.tag="4.1.4" \
+  --set ner.image.tag="4.1.4" \
+  --set ui.image.tag="4.1.0-20250513"
 ```
 
 **Upgrading with a values file:**
@@ -1076,8 +1076,8 @@ helm uninstall netapp-neo --namespace netapp-neo
 |-----------|-------------|---------|
 | `ui.name` | The base name for UI resources. | `neo-ui` |
 | `ui.replicaCount` | Number of UI pods to run. | `1` |
-| `ui.image.repository` | The UI container image repository. | `ghcr.io/beezy-dev/neo-ui-framework` |
-| `ui.image.tag` | UI image tag. | `3.2.2` |
+| `ui.image.repository` | The UI container image repository. | `ghcr.io/netapp/neo-ui-framework` |
+| `ui.image.tag` | UI image tag. | `4.1.0-20250513` |
 | `ui.image.pullPolicy` | The image pull policy. | `Always` |
 | `ui.service.type` | The type of Kubernetes service to create for UI. | `ClusterIP` |
 | `ui.service.port` | The port exposed by the UI service. | `80` |

--- a/docs/projects/mlai/neo/core/security.md
+++ b/docs/projects/mlai/neo/core/security.md
@@ -18,20 +18,20 @@ NetApp Project Neo is a secure enterprise application that indexes content from 
                               │ HTTPS
                               ▼
 ┌─────────────┐  ┌──────────────────────────────────────────────────────────┐
-│ MCP Clients │  │  neo-network (Docker bridge)                             │
+│ MCP Clients │  │  Internal Network                                        │
 │ (AI tools)  │  │                                                          │
 └──────┬──────┘  │  ┌──────────┐  ┌────────┐  ┌────────┐  ┌────────────┐    │
        │         │  │   API    │  │ Worker │  │  NER   │  │ Extractor  │    │
-       │ HTTPS   │  │  :8000   │─►│(intern)│─►│(intern)│  │  (intern)  │    │
-       └────────►│  └────┬─────┘  │        │  │GLiNER2 │  │GPU-accel.  │    │
+       │ HTTPS   │  │ Service  │─►│Service │─►│Service │  │  Service   │    │
+       └────────►│  └────┬─────┘  │        │  │        │  │ GPU-accel. │    │
                  │       │        └────────┘  └────────┘  └──────┬─────┘    │
 ┌─────────────┐  │       │                           ▲           │          │
 │  Neo UI     │  │       │                           └───────────┘          │
-│  :8081      │──►       │                       Worker orchestrates        │
+│             │──►       │                       Worker orchestrates        │
 └─────────────┘  │       ▼                                       │          │
                  │  ┌──────────┐                                 │          │
                  │  │PostgreSQL│                                 │          │
-                 │  │  :5432   │                                 │          │
+                 │  │          │                                 │          │
                  │  └──────────┘                                 │          │
                  └───────────────────────────────────────────────┼──────────┘
                                                                  │
@@ -49,15 +49,15 @@ NetApp Project Neo is a secure enterprise application that indexes content from 
 
 ### Microservices
 
-Neo v4 is composed of four microservices communicating over an internal Docker network (`neo-network`):
+Neo v4 is composed of microservices communicating over an isolated internal network:
 
-1. **API Service** (port 8000): FastAPI application handling REST API, MCP server, authentication, and share management. Exposed externally.
-1. **Neo UI** (port 8081): Web-based management console (separate container: `ghcr.io/beezy-dev/neo-ui-framework`). Connects to the API service internally. Exposed externally.
-1. **Worker Service** (internal only): Background service that crawls file shares, enumerates directories, processes work queue items, and uploads content to Microsoft Graph.
-1. **Extractor Service** (internal only): GPU-accelerated document content extraction using Docling. Converts files (PDF, DOCX, PPTX, etc.) to markdown for indexing.
-1. **NER Service** (internal only): Named Entity Recognition using GLiNER2 for entity extraction, document classification, and structured data extraction from indexed content.
-1. **Database Layer**: PostgreSQL (primary) or MySQL for metadata, user accounts, work queues, and operational logs.
-1. **Security Manager**: Shared library (`netapp_shared/security/`) providing authentication, encryption, OAuth validation, and access control across all services.
+1. **API Service**: Handles REST API, MCP server, authentication, and share management. Exposed externally.
+1. **Neo UI**: Web-based management console. Connects to the API service internally. Exposed externally.
+1. **Worker Service** (internal only): Background service that crawls file shares, enumerates directories, and uploads content to Microsoft Graph.
+1. **Extractor Service** (internal only): GPU-accelerated document content extraction. Converts files (PDF, DOCX, PPTX, etc.) to searchable text for indexing.
+1. **NER Service** (internal only): Named Entity Recognition for entity extraction, document classification, and structured data extraction from indexed content.
+1. **Database Layer**: PostgreSQL (recommended) or MySQL for metadata, user accounts, and operational data.
+1. **Security Manager**: Shared component providing authentication, encryption, OAuth validation, and access control across all services.
 
 ### Firewall Rules
 
@@ -78,14 +78,8 @@ Neo supports multiple authentication mechanisms depending on the access path.
 
 #### JWT-Based Authentication (Admin UI / REST API)
 
-- **Algorithm**: HS256 (HMAC with SHA-256)
 - **Token Expiration**: Configurable via `ACCESS_TOKEN_EXPIRE_MINUTES` (default: 24 hours / 1440 minutes)
-- **Secret Key Management** (priority order):
-  1. `JWT_SECRET_KEY` environment variable (highest priority)
-  2. Database-stored key in `system_config` table (recommended for multi-node)
-  3. Legacy file-based storage (`data/jwt_secret.key`, auto-migrated to database)
-  4. Auto-generated 256-bit key stored in database if none exists
-- **Internal Service Token**: Deterministic token derived from JWT secret for MCP-to-API internal calls (localhost only)
+- **Secret Key Management**: Keys can be provided via environment variable (`JWT_SECRET_KEY`) or are automatically generated and stored securely. Multi-node deployments should set the key via environment variable to ensure consistency across replicas.
 
 #### OAuth 2.0 / Microsoft Entra ID (MCP Server)
 
@@ -136,21 +130,16 @@ For CLI tools, automation, and environments where OAuth is not practical, Neo su
 #### At-Rest Encryption
 
 - **Database**: PostgreSQL with filesystem-level encryption support
-- **Credential Storage**: SMB/NFS passwords and OAuth secrets encrypted using Fernet (AES-128 in CBC mode with HMAC authentication)
-- **Key Management** (priority order):
-  1. `ENCRYPTION_KEY` environment variable (highest priority, recommended for multi-node)
-  2. Database-stored key in `system_config` table (auto-generated if not present)
-  3. Legacy file-based storage (`data/key.key`, auto-migrated to database on first use)
-  4. Auto-generated Fernet key stored in database if none exists
-- **Key Format**: 256-bit URL-safe base64-encoded Fernet keys
-- **Sensitive Config**: The `system_config` table supports `is_sensitive` flag and `config_type='secret'` for encryption keys, JWT secrets, and other sensitive values
+- **Credential Storage**: SMB/NFS passwords and OAuth secrets are encrypted at rest using industry-standard authenticated encryption
+- **Key Management**: Encryption keys can be provided via the `ENCRYPTION_KEY` environment variable (recommended for multi-node deployments) or are automatically generated and stored securely
+- **Sensitive Data**: Sensitive configuration values including encryption keys and secrets are stored with additional protection
 
 #### In-Transit Encryption
 
 - **HTTPS**: Application designed to run behind HTTPS proxy/load balancer
 - **Microsoft Graph API**: All communications over HTTPS
 - **SMB Connections**: Supports SMB encryption when available on target shares
-- **Internal Services**: Services communicate over Docker bridge network (`neo-network`); TLS termination at the ingress layer
+- **Internal Services**: Services communicate over an isolated Docker bridge network; TLS termination at the ingress layer
 
 ### Access Control & Permissions
 
@@ -177,33 +166,26 @@ Microsoft Graph integration is optional. It is only required when using Neo with
 
 ### Network Security
 
-#### Service Architecture & Ports
+#### Service Architecture
 
-| Service    | Port | Exposure      | Purpose                               |
-| ---------- | ---- | ------------- | ------------------------------------- |
-| API        | 8000 | External      | REST API and MCP server               |
-| UI         | 8081 | External      | Web administration interface          |
-| Worker     | --   | Internal only | File crawling, Graph sync, work queue |
-| Extractor  | 8000 | Internal only | Document content extraction (GPU)     |
-| NER        | 8000 | Internal only | Named entity recognition (GPU)        |
-| PostgreSQL | 5432 | Internal only | Database                              |
+| Service    | Exposure      | Purpose                               |
+| ---------- | ------------- | ------------------------------------- |
+| API        | External      | REST API and MCP server               |
+| UI         | External      | Web administration interface          |
+| Worker     | Internal only | File crawling, Graph sync             |
+| Extractor  | Internal only | Document content extraction (GPU)     |
+| NER        | Internal only | Named entity recognition (GPU)        |
+| PostgreSQL | Internal only | Database                              |
 
-#### Container Security (Per-Service)
+#### Container Security
 
-Each microservice runs with the minimum privileges required for its function:
-
-| Service   | User          | Capabilities                             | Privileged | Notes                                 |
-| --------- | ------------- | ---------------------------------------- | ---------- | ------------------------------------- |
-| API       | netapp (1000) | None required                            | No         | Minimal privileges                    |
-| Worker    | netapp (1000) | SYS_ADMIN, DAC_READ_SEARCH, DAC_OVERRIDE | No         | Required for SMB/NFS mounting         |
-| Extractor | netapp (1000) | (varies)                                 | Yes        | Privileged mode for GPU device access |
-| NER       | netapp (1000) | None required                            | No         | Minimal privileges                    |
+Each microservice runs with the minimum privileges required for its function. The API and NER services run with no additional capabilities. The Worker service requires elevated capabilities for mounting SMB/NFS shares. The Extractor service requires GPU device access.
 
 #### Network Isolation
 
-- **Internal Network**: All services communicate over the `neo-network` Docker bridge network
-- **External Access**: Only the API service (port 8000) and Neo UI (port 8081) are exposed outside the Docker network — these are separate containers
-- **Worker, Extractor, NER**: Not directly accessible from outside `neo-network`
+- **Internal Network**: All services communicate over an isolated Docker bridge network
+- **External Access**: Only the API service and Neo UI are exposed externally
+- **Worker, Extractor, NER**: Not directly accessible from outside the internal network
 - **External Dependencies**: SMB/NFS/S3 file shares; optionally Microsoft Graph API (HTTPS) and Entra ID JWKS endpoints (only when Graph or MCP OAuth is enabled)
 
 ## Security Controls Implementation
@@ -214,7 +196,7 @@ Each microservice runs with the minimum privileges required for its function:
 
 - **Pydantic Models**: Strict data validation for all API inputs
 - **Path Traversal Protection**: Validates file paths to prevent directory traversal
-- **SQL Injection Prevention**: Parameterized queries throughout database layer (56+ shared Database methods)
+- **SQL Injection Prevention**: Parameterized queries throughout the database layer
 - **XSS Protection**: Input sanitization for user-provided content
 - **MCP Content Windowing**: Configurable content window sizes (`MCP_DEFAULT_WINDOW_SIZE`, `MCP_MAX_WINDOW_SIZE`) to prevent excessive data transfer
 
@@ -285,14 +267,14 @@ The following operation types are tracked in the audit log:
 - **NER Processing**: Optional entity extraction identifies people, organizations, locations, and custom entity types
 - **Metadata Only Mode**: Option to index only metadata without content
 - **Data Retention**: Configurable retention policies for indexed content
-- **Full-Text Search**: GIN-indexed search vectors for efficient content search without scanning raw data
+- **Full-Text Search**: Optimized search indexes for efficient content search without scanning raw data
 
 #### Personal Data Protection
 
 - **ACL Preservation**: Maintains original file permissions in Microsoft Graph and MCP responses
 - **User Attribution**: Tracks user actions for compliance reporting
 - **Data Minimization**: Only processes necessary file metadata and content
-- **Right to Deletion**: Support for removing indexed content (shared `delete_share()` cleans up files, NER results, Graph items, and work queue entries)
+- **Right to Deletion**: Support for removing indexed content — deleting a share cleans up all associated files, NER results, Graph items, and work queue entries
 
 ### Compliance Features
 
@@ -346,7 +328,7 @@ securityContext:
   runAsGroup: 1000
   allowPrivilegeEscalation: true # Required for SMB/NFS mounting
   capabilities:
-    add: ["SYS_ADMIN", "DAC_READ_SEARCH", "DAC_OVERRIDE"]
+    add: [...]  # See deployment guide for required capabilities
 ```
 
 **Extractor Service** (requires GPU device access):
@@ -360,8 +342,8 @@ securityContext:
 
 #### Network Policies
 
-- **Ingress Control**: Only the API service (port 8000) and Neo UI (port 8081) should receive external traffic
-- **Internal Traffic**: Worker, Extractor, and NER services accept traffic only from within `neo-network`
+- **Ingress Control**: Only the API service and Neo UI should receive external traffic
+- **Internal Traffic**: Worker, Extractor, and NER services accept traffic only from within the internal network
 - **Egress Control**: Allow outbound traffic to SMB/NFS/S3 file shares and HuggingFace (model downloads); optionally Microsoft Graph and Entra ID JWKS when those integrations are enabled
 - **Service Mesh**: Compatible with service mesh security policies
 
@@ -403,13 +385,13 @@ ACCESS_TOKEN_EXPIRE_MINUTES=1440           # Default: 24 hours
 - **Secret Objects**: Store sensitive configuration in Kubernetes secrets
 - **Volume Mounts**: Mount secrets as files rather than environment variables
 - **RBAC**: Restrict access to secret objects
-- **Database-Backed Keys**: Encryption and JWT keys stored in the `system_config` table are automatically generated if not provided via environment variables, ensuring keys persist across container restarts without requiring external secret management
+- **Database-Backed Keys**: Encryption and JWT keys are automatically generated if not provided via environment variables, ensuring keys persist across container restarts without requiring external secret management
 
 ## Security Best Practices
 
 ### Deployment Recommendations
 
-1. **Network Segmentation**: Deploy in isolated network segments; only expose API (port 8000) and Neo UI (port 8081)
+1. **Network Segmentation**: Deploy in isolated network segments; only expose the API service and Neo UI externally
 2. **HTTPS Termination**: Use reverse proxy/load balancer for HTTPS in front of the API service
 3. **Regular Updates**: Keep base images and dependencies updated
 4. **Monitoring**: Implement comprehensive monitoring and alerting across all four services
@@ -437,11 +419,11 @@ ACCESS_TOKEN_EXPIRE_MINUTES=1440           # Default: 24 hours
 
 ### Known Limitations
 
-1. **SMB Authentication**: Share passwords stored encrypted (Fernet) but accessible to the Worker service at runtime
-2. **Privileged Capabilities**: Worker requires SYS_ADMIN/DAC_READ_SEARCH for SMB/NFS mounting; Extractor requires privileged mode for GPU access
+1. **SMB Authentication**: Share passwords are stored encrypted but accessible to the Worker service at runtime
+2. **Privileged Capabilities**: Worker requires elevated capabilities for SMB/NFS mounting; Extractor requires GPU device access
 3. **Content Processing**: Processes file content which may contain sensitive data (mitigated by ACL filtering)
 4. **Network Access**: Requires network access to file shares; Microsoft Graph and Entra ID access only required when those integrations are enabled
-5. **Internal Network Trust**: Services on `neo-network` communicate without mutual TLS (suitable for single-host Docker deployments; consider service mesh for multi-node)
+5. **Internal Network Trust**: Internal services communicate without mutual TLS (suitable for single-host Docker deployments; consider service mesh for multi-node)
 
 ### Risk Mitigation
 
@@ -471,8 +453,8 @@ ACCESS_TOKEN_EXPIRE_MINUTES=1440           # Default: 24 hours
 ## Version Information
 
 - **Document Version**: 2.0
-- **Last Updated**: 2026-03-10
-- **Neo Version**: 4.0.2
+- **Last Updated**: 2026-05-21
+- **Neo Version**: 4.1.4
 - **Review Date**: Annual review required
 
 ---

--- a/docs/projects/mlai/neo/core/troubleshooting.md
+++ b/docs/projects/mlai/neo/core/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting
 
-This guide covers common issues and solutions for NetApp Project Neo v4.0.2 and its multi-service architecture.
+This guide covers common issues and solutions for NetApp Project Neo and its multi-service architecture.
 
 ## How to log a support case / idea
 
@@ -40,9 +40,9 @@ Neo v4 uses a multi-service architecture with independently scalable components.
    ```bash
    docker compose ps
    ```
-2. Confirm services are on the same Docker network (`neo-network`):
+2. Confirm services are on the same Docker network:
    ```bash
-   docker network inspect neo-network
+   docker network ls
    ```
 3. Check that `WORKER_SERVICE_URL`, `EXTRACTOR_SERVICE_URL`, and `NER_SERVICE_URL` are set correctly. Default values in `docker-compose.yml`:
    - API -> Worker: `http://worker:8000`
@@ -114,19 +114,19 @@ Database schema migrations run automatically on service startup. If a migration 
    ```
 3. For locking issues during migration (multiple services migrating simultaneously), Neo uses advisory locks. If a migration lock is stuck, restart all services — the lock is session-based and will be released.
 
-### system_config table missing
+### Configuration table missing
 
-The `system_config` table stores encryption keys, JWT secrets, and other shared configuration. It is created automatically on first startup by whichever service starts first.
+The system configuration table stores encryption keys, JWT secrets, and other shared configuration. It is created automatically on first startup by whichever service starts first.
 
-If you see errors about `system_config` not existing:
+If you see errors about missing configuration tables:
 1. Ensure at least one service (API or worker) has started successfully against the database at least once.
 2. Check that the database user has `CREATE TABLE` privileges.
 
 ### Encryption key errors
 
-**Error:** `InvalidToken` or `Fernet key error` when accessing shares
+**Error:** `InvalidToken` or encryption key errors when accessing shares
 
-The `ENCRYPTION_KEY` is a Fernet key used to encrypt sensitive data (e.g., SMB passwords). It is auto-generated and stored in the `system_config` table on first startup.
+The `ENCRYPTION_KEY` is used to encrypt sensitive data (e.g., SMB passwords). It is auto-generated and stored in the database on first startup.
 
 - **All services must use the same encryption key.** If services share the same `DATABASE_URL`, they retrieve the key from the database automatically.
 - If you set `ENCRYPTION_KEY` as an environment variable, it overrides the database-stored key. Ensure all services use the same value.
@@ -326,20 +326,16 @@ Files with unsupported extensions are skipped during crawling. Check the work qu
 
 ### Search is slow
 
-Neo v4 uses PostgreSQL GIN-indexed `search_vector` columns for full-text search, providing 20-42x speedup over unindexed queries.
+Neo v4 uses optimized full-text search indexes for high-performance content search.
 
 If search is slow:
 
-1. Verify the GIN index exists:
-   ```sql
-   SELECT indexname FROM pg_indexes WHERE tablename = 'file_metadata' AND indexname = 'idx_file_metadata_search_vector';
-   ```
-2. If the index is missing, it is created automatically during migration. Restart the API service to trigger migration.
-3. For large databases, `VACUUM ANALYZE file_metadata` can help the query planner:
+1. Verify the search indexes exist — they are created automatically during database migration. Restart the API service to trigger migration if needed.
+2. For large databases, running PostgreSQL `VACUUM ANALYZE` can help the query planner:
    ```bash
-   docker exec neo-postgres psql -U neo -d neo_connector -c "VACUUM ANALYZE file_metadata;"
+   docker exec neo-postgres psql -U neo -d neo_connector -c "VACUUM ANALYZE;"
    ```
-4. Check that queries are using `websearch_to_tsquery` (the indexed path) rather than `LIKE` or `ILIKE` patterns.
+3. Check the [Performance & Benchmarking](m-performance) guide for tuning recommendations.
 
 ### ACL resolution slow
 
@@ -377,9 +373,9 @@ If the overall system throughput is lower than expected:
 
 | Error Message | Cause | Solution |
 |---|---|---|
-| `InvalidToken` or `Fernet key error` | Encryption key mismatch between services | Ensure all services share the same `DATABASE_URL` or set the same `ENCRYPTION_KEY` |
+| `InvalidToken` or encryption key error | Encryption key mismatch between services | Ensure all services share the same `DATABASE_URL` or set the same `ENCRYPTION_KEY` |
 | `connection refused` on port 5432 | PostgreSQL not running or unreachable | Check `docker logs neo-postgres` and verify `DATABASE_URL` |
-| `system_config table does not exist` | Database not initialized | Restart the API service to trigger auto-migration |
+| Configuration table not found | Database not initialized | Restart the API service to trigger auto-migration |
 | `429 Too Many Requests` | Microsoft Graph rate limit exceeded | Reduce `NUM_UPLOAD_WORKERS` or lower `GRAPH_RATE_LIMIT` |
 | `401 Unauthorized` on MCP endpoints | Invalid OAuth token or API key | Verify `MCP_OAUTH_*` settings or `MCP_API_KEY` value |
 | `502 Bad Gateway` from API | Worker service unreachable | Check `docker compose ps` and `WORKER_SERVICE_URL` |

--- a/docs/projects/mlai/neo/examples/docker-compose.example.yaml
+++ b/docs/projects/mlai/neo/examples/docker-compose.example.yaml
@@ -176,7 +176,7 @@ services:
   # crawls, and managing the connector. Connects to the API service.
   neoui:
     hostname: neoui
-    image: ghcr.io/beezy-dev/neo-ui-framework:${NUI_VERSION}
+    image: ghcr.io/netapp/neo-ui-framework:${NUI_VERSION}
     container_name: neoui
     ports:
       - "8080:80"

--- a/docs/projects/mlai/neo/examples/docker-compose.example.yml-bkp
+++ b/docs/projects/mlai/neo/examples/docker-compose.example.yml-bkp
@@ -60,7 +60,7 @@ services:
   # Lightweight FastAPI service handling HTTP endpoints, MCP transport, and
   # OAuth. No background processing — delegates to the worker service.
   api:
-    image: ghcr.io/netapp/netapp-neo-api:4.0.2
+    image: ghcr.io/netapp/netapp-neo-api:4.1.4
     ports:
       - "8000:8000"
     environment:
@@ -223,7 +223,7 @@ services:
   # backends: MarkItDown (Office/PDF), Docling (OCR/tables), Docling VLM
   # (vision language models). Mounts shares independently via CIFS.
   extractor:
-    image: ghcr.io/netapp/netapp-neo-extractor:4.0.2
+    image: ghcr.io/netapp/netapp-neo-extractor:4.1.4
     # privileged needed for NFS/CIFS mounting inside the container
     privileged: true
     environment:
@@ -302,7 +302,7 @@ services:
   # classifications (document type), and structured data. Stateless — no file
   # or database access needed.
   ner:
-    image: ghcr.io/netapp/netapp-neo-ner:4.0.2
+    image: ghcr.io/netapp/netapp-neo-ner:4.1.4
     environment:
       # NER_MODEL_NAME: Hugging Face model ID for GLiNER2. The model is
       # downloaded on first startup and cached in the container.
@@ -379,7 +379,7 @@ services:
   # Microsoft Graph upload, ACL resolution, and NER orchestration. Delegates
   # extraction to the extractor service and NER to the NER service.
   worker:
-    image: ghcr.io/netapp/netapp-neo-worker:4.0.2
+    image: ghcr.io/netapp/netapp-neo-worker:4.1.4
     cap_add:
       - SYS_ADMIN
       - DAC_READ_SEARCH
@@ -509,7 +509,7 @@ services:
   # Browser-based management console for configuring shares, monitoring
   # crawls, and managing the connector. Connects to the API service.
   neoui:
-    image: ghcr.io/beezy-dev/neo-ui-framework:3.2.2
+    image: ghcr.io/netapp/neo-ui-framework:4.1.0-20250513
     container_name: neoui
     ports:
       - "8081:80"

--- a/docs/projects/mlai/neo/examples/env
+++ b/docs/projects/mlai/neo/examples/env
@@ -8,8 +8,8 @@
 ## MUST BE CONFIGURED PARAMETERS
 # =============================================================================
 # Neo container image versioning
-NEO_VERSION=4.0.3p7
-NUI_VERSION=3.2.2
+NEO_VERSION=4.1.4
+NUI_VERSION=4.1.0-20250513
 
 ## Database Settings (required)
 # Modify accordingly to your preferences
@@ -37,11 +37,10 @@ POSTGRES_PORT=5432
 # ACCESS_TOKEN_EXPIRE_MINUTES=1440
 
 ## Encryption
-# ENCRYPTION_KEY: Fernet key for encrypting sensitive data (SMB
-# passwords). Auto-generated and stored in the database on first
-# startup if not set. All services sharing the same database will
-# retrieve the same key automatically. Only set this to override
-# the database-stored key.
+# ENCRYPTION_KEY: Key for encrypting sensitive data (SMB passwords).
+# Auto-generated and stored in the database on first startup if not
+# set. All services sharing the same database will retrieve the same
+# key automatically. Only set this to override the database-stored key.
 # ENCRYPTION_KEY=
 
 ## Microsoft Graph (optional - for M365 Copilot integration)

--- a/docs/projects/mlai/neo/examples/neo-containerfile.yml
+++ b/docs/projects/mlai/neo/examples/neo-containerfile.yml
@@ -21,7 +21,7 @@ services:
 
   # API Service (HTTP endpoints, MCP transport, OAuth)
   api:
-    image: ghcr.io/netapp/netapp-neo-api:4.0.2
+    image: ghcr.io/netapp/netapp-neo-api:4.1.4
     ports:
       - "8000:8000"
     environment:
@@ -58,7 +58,7 @@ services:
 
   # Extractor Service (content extraction: MarkItDown, Docling, VLM)
   extractor:
-    image: ghcr.io/netapp/netapp-neo-extractor:4.0.2
+    image: ghcr.io/netapp/netapp-neo-extractor:4.1.4
     privileged: true
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-neo}:${POSTGRES_PASSWORD:-neo_password}@postgres:5432/${POSTGRES_DB:-neo_connector}
@@ -84,7 +84,7 @@ services:
 
   # NER Service (Named Entity Recognition using GLiNER2)
   ner:
-    image: ghcr.io/netapp/netapp-neo-ner:4.0.2
+    image: ghcr.io/netapp/netapp-neo-ner:4.1.4
     environment:
       NER_CONFIDENCE_THRESHOLD: ${NER_CONFIDENCE_THRESHOLD:-0.7}
       NER_DEVICE: ${NER_DEVICE:-auto}
@@ -109,7 +109,7 @@ services:
 
   # Worker Service (background processing: crawling, upload, NER orchestration)
   worker:
-    image: ghcr.io/netapp/netapp-neo-worker:4.0.2
+    image: ghcr.io/netapp/netapp-neo-worker:4.1.4
     cap_add:
       - SYS_ADMIN
       - DAC_READ_SEARCH
@@ -149,7 +149,7 @@ services:
 
   # Neo UI (Web Management Console)
   neoui:
-    image: ghcr.io/beezy-dev/neo-ui-framework:3.2.2
+    image: ghcr.io/netapp/neo-ui-framework:4.1.0-20250513
     container_name: neoui
     ports:
       - "8081:80"

--- a/docs/projects/mlai/neo/uif/ui-framework.md
+++ b/docs/projects/mlai/neo/uif/ui-framework.md
@@ -19,7 +19,7 @@ The UI runs as a separate container (`neoui`) and is included in the standard Do
 
 ```yaml
 neoui:
-  image: ghcr.io/beezy-dev/neo-ui-framework:3.2.2
+  image: ghcr.io/netapp/neo-ui-framework:4.1.0-20250513
   ports:
     - "8081:80"
   environment:
@@ -32,4 +32,4 @@ Access the console at `http://your-server:8081` after deployment.
 
 For console usage details, see the [Console Guide](../core/m-console.md).
 
-The UI Framework is maintained separately at [beezy-dev/neo-ui-framework](https://github.com/beezy-dev/neo-ui-framework).
+The UI Framework is maintained separately at [netapp/neo-ui-framework](https://github.com/netapp/neo-ui-framework).


### PR DESCRIPTION
## Summary

- **New Virtual Datasets documentation** (`m-datasets.md`, 573 lines) — covers all 16 API endpoints, permission model (READ/WRITE/ADMIN/OWNER), sharing, ACL override, full-text and NER search, subset creation, expiration, rate limiting, and configuration
- **IP redaction** across 12 existing files — removed database schema names, algorithm thresholds/routing tables, encryption specifics, internal tuning parameters, adaptive batching details, and performance benchmarks that could help competitors recreate the product
- **Version updates** — core `4.0.2`/`4.0.3p7` → `4.1.4`, UI `3.2.2` → `4.1.0-20250513`, registry `beezy-dev` → `netapp` across all docs and examples
- **Navigation updates** — added Virtual Datasets to management.md and 16 endpoints to m-api.md API reference

## Files changed (21)

| Category | Files |
|----------|-------|
| **New** | `core/m-datasets.md` |
| **IP redaction** | `m-extraction.md`, `m-ner.md`, `m-search.md`, `m-performance.md`, `security.md`, `m-mcp.md`, `m-files.md`, `m-console.md`, `m-protocols.md`, `troubleshooting.md`, `d-configuration.md` |
| **Version updates** | `qs-docker.md`, `qs-kubernetes.md`, `m-api.md`, `security.md`, `env`, `docker-compose.example.yaml`, `docker-compose.example.yml-bkp`, `neo-containerfile.yml`, `ui-framework.md` |
| **Navigation** | `management.md`, `m-api.md` |

## Test plan

- [ ] Review `m-datasets.md` for accuracy against the source code API
- [ ] Verify no proprietary implementation details remain (grep for `system_config`, `file_metadata`, `search_vector`, `ts_rank_cd`, `Fernet`, `AES`, `HS256`, `neo-network`)
- [ ] Confirm all version strings updated to `4.1.4` / `4.1.0-20250513` (excluding legacy docs)
- [ ] Confirm `beezy-dev` registry references replaced with `netapp`
- [ ] Verify cross-references and navigation links work