### PR TITLE
docs: add Virtual Datasets to sidebar navigation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -82,6 +82,7 @@ export default defineConfig({
                 { text: 'Users', link: '/projects/mlai/neo/core/m-users' },
                 { text: 'Shares', link: '/projects/mlai/neo/core/m-shares' },
                 { text: 'Files', link: '/projects/mlai/neo/core/m-files' },
+                { text: 'Virtual Datasets', link: '/projects/mlai/neo/core/m-datasets' },
                 { text: 'Protocols', link: '/projects/mlai/neo/core/m-protocols' },
                 { text: 'Extraction', link: '/projects/mlai/neo/core/m-extraction' },
                 { text: 'Search', link: '/projects/mlai/neo/core/m-search' },


### PR DESCRIPTION
## Summary
- Adds Virtual Datasets entry to the VitePress sidebar navigation between Files and Protocols
- This was missed from PR #22 which added the `m-datasets.md` documentation

## Test plan
- [ ] Verify Virtual Datasets appears in the left navigation tree
- [ ] Verify the link navigates to the correct page